### PR TITLE
fix: adding jq to list of pre reqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL ubuntu="$UBUNTUVER"
 
 # install prerequisites
 RUN apt-get update \
-    && apt-get install -y librocksdb-dev curl xxd openssl binutils locales \
+    && apt-get install -y librocksdb-dev curl xxd openssl binutils locales jq \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8 \
     && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8


### PR DESCRIPTION
check-health.sh seem to be using "jq" binary and the node doesnt seem to contain the binary.


The below output is what I got running the `runonflux/chainweb-node-docker:latest` image on Flux
```
" Health": {
            "Status": "unhealthy",
            "FailingStreak": 190,
            "Log": [
                {
                    "Start": "2022-06-06T18:08:50.25164688+02:00",
                    "End": "2022-06-06T18:08:50.395293799+02:00",
                    "ExitCode": 1,
                    "Output": "./check-health.sh: line 13: jq: command not found\n(23) Failed writing body\n"
                },
                {
                    "Start": "2022-06-06T18:09:50.398689167+02:00",
                    "End": "2022-06-06T18:09:50.495335285+02:00",
                    "ExitCode": 1,
                    "Output": "./check-health.sh: line 13: jq: command not found\n(23) Failed writing body\n"
                },
                {
                    "Start": "2022-06-06T18:10:50.499227194+02:00",
                    "End": "2022-06-06T18:10:51.193514249+02:00",
                    "ExitCode": 1,
                    "Output": "./check-health.sh: line 13: jq: command not found\n(23) Failed writing body\n"
                },
                {
                    "Start": "2022-06-06T18:11:51.250092883+02:00",
                    "End": "2022-06-06T18:11:51.488642976+02:00",
                    "ExitCode": 1,
                    "Output": "./check-health.sh: line 13: jq: command not found\n(23) Failed writing body\n"
                },
                {
                    "Start": "2022-06-06T18:12:51.49289035+02:00",
                    "End": "2022-06-06T18:12:51.616305351+02:00",
                    "ExitCode": 1,
                    "Output": "./check-health.sh: line 13: jq: command not found\n(23) Failed writing body\n"
                }
            ]
}
```